### PR TITLE
Correct link to chriskempson GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ whatever it was before installing. Some uninstallation steps will be manual.
 
 - Thanks to Square for their (now unmaintained) [maximum-awesome](https://github.com/square/maximum-awesome) repo
 - Thanks to Tim Pope for his vim plugins
-- Thanks to GitHub user [chriskempson](github.com/chriskempson) for his base16 work
+- Thanks to GitHub user [chriskempson](https://github.com/chriskempson) for his base16 work


### PR DESCRIPTION
I stumbled upon this repository, and while reading the ReadMe, I noticed a link that didn't work, so here's a PR 😀 